### PR TITLE
Add regular user 'docker'

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -24,6 +24,15 @@ RUN echo "deb http://http.debian.net/debian sid main" > /etc/apt/sources.list.d/
     apt-get -y update && \
     DEBIAN_FRONTEND=noninteractive apt-get -yq install rcheckserver
 
+## Set a default user. Available via runtime flag
+## Add user to 'staff' group, granting them write privileges to
+## /usr/local/lib/R/site.library
+## User should also have & own a home directory
+RUN useradd docker \
+	&& mkdir /home/docker \
+	&& chown docker:docker /home/docker \
+	&& addgroup docker staff
+
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/debian/entrypoint.sh
+++ b/debian/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # start fake X server
-nohup Xvfb :6 -screen 0 1280x1024x24 > /X.log 2>&1 &
+nohup Xvfb :6 -screen 0 1280x1024x24 > ~/X.log 2>&1 &
 
 export DISPLAY=:6
 

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -24,6 +24,15 @@ RUN echo "deb http://statmath.wu.ac.at/AASC/debian testing main non-free" > /etc
     apt-get -y update && \
     DEBIAN_FRONTEND=noninteractive apt-get -yq install rcheckserver
 
+## Set a default user. Available via runtime flag
+## Add user to 'staff' group, granting them write privileges to
+## /usr/local/lib/R/site.library
+## User should also have & own a home directory
+RUN useradd docker \
+	&& mkdir /home/docker \
+	&& chown docker:docker /home/docker \
+	&& addgroup docker staff
+
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/ubuntu/entrypoint.sh
+++ b/ubuntu/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # start fake X server
-nohup Xvfb :6 -screen 0 1280x1024x24 > /X.log 2>&1 &
+nohup Xvfb :6 -screen 0 1280x1024x24 > ~/X.log 2>&1 &
 
 export DISPLAY=:6
 


### PR DESCRIPTION
So that R does not have to run as root. This also makes the containers compatible with R-hub.

The default user is still root, though, so  one has to explicitly start the container with `-u docker`.